### PR TITLE
Missing routes with same path but different methods from swagger docs

### DIFF
--- a/src/app-config.ts
+++ b/src/app-config.ts
@@ -106,14 +106,16 @@ export class AppConfig {
           fullRoutePath,
           routeHandlerName,
           routeMethod: routeHandlerMetadata.method,
-          routeHandler: controllerInstance[routeHandlerName].bind(controllerInstance),
+          routeHandler:
+            controllerInstance[routeHandlerName].bind(controllerInstance),
         });
 
         this.addRouteToSwagger(controller, {
           fullRoutePath,
           routeHandlerName,
           routeMethod: routeHandlerMetadata.method,
-          routeHandler: controllerInstance[routeHandlerName].bind(controllerInstance),
+          routeHandler:
+            controllerInstance[routeHandlerName].bind(controllerInstance),
         });
       });
     }
@@ -208,6 +210,9 @@ export class AppConfig {
         return `{${param.slice(1)}}`;
       })
       .slice(0, -1);
-    this.swaggerConfig.paths[swaggerRoutePath] = swaggerPathItemObject;
+    this.swaggerConfig.paths[swaggerRoutePath] = {
+      ...this.swaggerConfig.paths[swaggerRoutePath],
+      ...swaggerPathItemObject,
+    };
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message and branch names follows our guidelines: [Contributing guidelines](https://github.com/AmishFaldu/Swagger-Docs/blob/master/CONTRIBUTING.md)
- [X] Tests for the changes have been done (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes)
- [ ] Docs improved or updated (no changes in code)
- [ ] Other... Please describe:

## What is the current behavior?

Currently, when we create APIs with multiple routes with same path but different method. Only last one of them gets registered in swagger config and hence only one route is shown with same path.

## What is the new behavior?

Now, when there are multiple routes with same path bu different methods. They will be registered in swagger config and shown in the swagger docs also

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No