### PR TITLE
Added deep copy to update reflect metadata defensively

### DIFF
--- a/src/decorators/dto.decorator.ts
+++ b/src/decorators/dto.decorator.ts
@@ -1,4 +1,5 @@
 import "reflect-metadata";
+import { deepCopyObject } from "../utils/helper-function.util";
 import { DTO_DECORATOR_METADATA_ENUM } from "../constants/decorator.constants";
 import {
   ClassType,
@@ -79,9 +80,16 @@ const addPropertyToSwaggerSchema = ({
       Reflect.getMetadata(DTO_DECORATOR_METADATA_ENUM.DTO_SCHEMA, target);
 
     const objectType = Reflect.getMetadata("design:type", target, property);
-    const swaggerSchema: ISwaggerSchema = exsitingSwaggerSchema ?? {
-      type: "object",
-    };
+
+    // We want to deep copy the schema object and after then assign to reflect metadata
+    // This will make sure that base classes with child extends don't get properties of child class
+    // P.S. - Don't remove the deep copy unless you know what you're doing.
+    // Reference issue - https://github.com/rbuckton/reflect-metadata/issues/62
+    const swaggerSchema: ISwaggerSchema = deepCopyObject(
+      exsitingSwaggerSchema ?? {
+        type: "object",
+      },
+    );
 
     swaggerSchema.properties = swaggerSchema.properties ?? {};
     swaggerSchema.properties[property] = {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message and branch names follows our guidelines: [Contributing guidelines](https://github.com/AmishFaldu/Swagger-Docs/blob/master/CONTRIBUTING.md)
- [X] Tests for the changes have been done (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes)
- [ ] Docs improved or updated (no changes in code)
- [ ] Other... Please describe:

## What is the current behavior?

Currently when a child DTO class is extending from base DTO class, the properties of child schema are also assigned to base schema
Reference issue link - https://github.com/rbuckton/reflect-metadata/issues/62, https://github.com/rbuckton/reflect-metadata/issues/53

## What is the new behavior?

Now with the fix of deep copy, the base class doesn't have properties of child class when inheriting.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No